### PR TITLE
new localites query based on healthcenters

### DIFF
--- a/src/database/schemas/localitiesRefes.schema.ts
+++ b/src/database/schemas/localitiesRefes.schema.ts
@@ -1,0 +1,8 @@
+import * as mongoose from 'mongoose';
+
+const LocalitiesRefesSchema = new mongoose.Schema({
+  _id: String,
+  localidad: String,
+});
+
+export default LocalitiesRefesSchema;

--- a/src/modules/health-centers/dto/getLocalities.dto.ts
+++ b/src/modules/health-centers/dto/getLocalities.dto.ts
@@ -1,0 +1,4 @@
+export class GetLocalitiesDto {
+    readonly _id: string;
+    readonly localidad: string;
+  }

--- a/src/modules/health-centers/health-centers.controller.ts
+++ b/src/modules/health-centers/health-centers.controller.ts
@@ -13,8 +13,13 @@ export class HealthCentersController {
   }
 
   @Get('localities')
-  async findAllByLocalityId(@Query('localityId') localityId: number) {
+  async findAllByLocalityId(@Query('localityId') localityId: string) {
     return this.healthCenterSvc.findAllByLocalityId(localityId);
+  }
+
+  @Get('localitieslist')
+  async findAllLocalitiesByProvinceId(@Query('provinceId') provinciaId: string) {
+    return this.healthCenterSvc.findAllLocalitiesByProvinceId(provinciaId);
   }
 
   @Post()

--- a/src/modules/health-centers/health-centers.module.ts
+++ b/src/modules/health-centers/health-centers.module.ts
@@ -4,12 +4,14 @@ import { HealthCentersService } from './health-centers.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import HealthCenterSchema from '../../database/schemas/healthCenter.schema';
 import HealthCenterCategorySchema from '../../database/schemas/healthCenterCategory.schema';
+import LocalitiesRefesSchema from '../../database/schemas/localitiesRefes.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: 'HealthCenter', schema: HealthCenterSchema },
       { name: 'HealthCenterCategory', schema: HealthCenterCategorySchema },
+      { name: 'LocalitiesRefes', schema: LocalitiesRefesSchema },
     ]),
   ],
   controllers: [HealthCentersController],

--- a/src/modules/health-centers/health-centers.service.ts
+++ b/src/modules/health-centers/health-centers.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { HealthCenter } from './interfaces/HealthCenter';
+import { LocalitiesRefes } from './interfaces/LocalitiesRefes';
 import { Model } from 'mongoose';
 import { CreateHealthCenterDto } from './dto/createHealthCenter.dto';
 import { HealthCenterCategory } from './interfaces/HealthCenterCategory';
 import { CreateHealthCenterCategoryDto } from './dto/createHealthCenterCategory.dto';
 import { GetHealthCenterCategoriesDto } from './dto/getHealthCentersCategories.dto';
+import { GetLocalitiesDto } from './dto/getLocalities.dto';
 import { GetHealthCenterDto } from './dto/getHealthCenters.dto';
 import * as mongoose from 'mongoose';
 
@@ -15,15 +17,24 @@ export class HealthCentersService {
     @InjectModel('HealthCenter') private healthCenter: Model<HealthCenter>,
     @InjectModel('HealthCenterCategory')
     private healthCenterCategory: Model<HealthCenterCategory>,
+    @InjectModel('LocalitiesRefes')
+    private localitiesRefes: Model<LocalitiesRefes>,
   ) {}
 
   async findAll(): Promise<GetHealthCenterDto[]> {
     return this.healthCenter.find().exec();
   }
 
-  async findAllByLocalityId(localidadId: number):Promise<GetHealthCenterDto[]>{
+  async findAllByLocalityId(localidadId: string):Promise<GetHealthCenterDto[]>{
     return this.healthCenter.find({'address.locality_id': localidadId}).exec();
   }
+
+ // este metodo adhoc para buscar localidades dentro de la base de REFES
+  async findAllLocalitiesByProvinceId(provinceId: string):Promise<GetLocalitiesDto[]>{
+
+    return this.healthCenter.aggregate([{ '$match': { "address.province_id": provinceId } },{ '$group': { '_id': "$address.locality_id", 'localidad': { '$first': "$address.city" } } }, {"$sort": {"localidad": 1}}]).exec();
+
+    }
 
   async findAllCategories(): Promise<GetHealthCenterCategoriesDto[]> {
     return this.healthCenterCategory.find({}).exec();

--- a/src/modules/health-centers/interfaces/LocalitiesRefes.ts
+++ b/src/modules/health-centers/interfaces/LocalitiesRefes.ts
@@ -1,0 +1,6 @@
+import { Document } from 'mongoose';
+
+export interface LocalitiesRefes extends Document {
+  readonly _id: string;
+  readonly localidad: string;
+}


### PR DESCRIPTION
Sume un servicio adhoc para consultar las localidades por provincia, de acuerdo a lo que está en la base de datos de health centers. Lo hice para solucionar el problema de mismatch entre los ids de localidades oficiales de api.gov.ar y los que están en nuestra base de efectores.
