### PR TITLE
Se agrega el endpoint para obtener información por número de seguimiento

### DIFF
--- a/src/modules/donations/donations.service.ts
+++ b/src/modules/donations/donations.service.ts
@@ -84,4 +84,32 @@ export class DonationsService {
     createdDonation = await this.findById(createdDonation.id);
     return createdDonation
   }
+
+  async findByTrackingNumber(trackingNumber: string): Promise<Donation> {
+
+    return this
+          .donationModel
+          .findOne()
+          .where('tracking.number')
+          .equals(trackingNumber)
+          .exec();
+  }
+
+  async findByOrderId(orderId: string): Promise<Donation[]> {
+
+    let finalId: mongoose.Types.ObjectId;
+
+    try {
+      finalId = new mongoose.Types.ObjectId(orderId);  
+    } catch(e) {
+      return null;
+    }
+    
+    return this
+          .donationModel
+          .find()
+          .where("order_id")
+          .equals(finalId)
+          .exec();
+  }
 }

--- a/src/modules/donations/dto/order-out.dto.ts
+++ b/src/modules/donations/dto/order-out.dto.ts
@@ -4,6 +4,7 @@ import { HealthCenter } from '../../health-centers';
 
 export class OrderOutDto {
 
+	readonly priority: number;
 	readonly healthCenterId: string;
 	readonly location: {
 		latitude: number,
@@ -13,6 +14,8 @@ export class OrderOutDto {
 
 
 	constructor(order: Order, healthCenter: HealthCenter | string) {
+
+		this.priority = order.priority;
 
 		if (typeof healthCenter === "string") {
 			this.healthCenterId = healthCenter;

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -30,8 +30,23 @@ export class OrdersService {
     private trackingNumberGenerator: TrackingNumberGeneratorService
 ) {}
 
-  async findById(id: string): Promise<Order> {
-    return this.orderModel.findById(id).exec();
+  async findById(id: mongoose.Schema.Types.ObjectId | string): Promise<Order> {
+
+    let finalId;
+
+    if (typeof id === "string") {
+      try {
+        //A invalid ID means that it was not found
+        finalId = new mongoose.Schema.Types.ObjectId(id);  
+      } catch(e) {
+        return null;
+      }
+      
+    } else {
+      finalId = id;
+    }
+
+    return this.orderModel.findById(finalId).exec();
   }
 
   async findAll(): Promise<Order[]> {
@@ -154,4 +169,13 @@ export class OrdersService {
       ]).exec();
   }
 
+  async findByTrackingNumber(trackingNumber: string): Promise<Order> {
+
+    return this
+          .orderModel
+          .findOne()
+          .where("tracking.number")
+          .equals(trackingNumber)
+          .exec();
+  }
 }


### PR DESCRIPTION
Se agrega el endpoint **GET /donations/tracking/:trackingNumber**, donde **:trackingNumber** puede ser el número de seguimiento de una petición ó una donación.

Si el número de seguimiento es de una petición, se obtiene los datos de la misma con todas sus donaciones asociadas. En cambio, si corresponde a una donación, se obtiene los datos de la petición a la que se encuentra asociada y solamente esa donación.

Si el número de seguimiento no se encuentra en ninguno de los dos casos, se retorna un código HTTP 404.

El JSON a retornar es el mismo para cualquiera de los dos casos. El mismo está definido de la siguiente manera:

`
{
 order: /modules/donations/dto/order-out.dto.ts,
 donations: [/modules/donations/dto/donation-out.dto.ts]
}
`


Para probar el endpoing:

- Número de seguimiento de donación: **20200402c7289**

- Número de seguimiento de petición de donación: **202004028f0bf**